### PR TITLE
Stokes V support

### DIFF
--- a/vasttools/find_racs.py
+++ b/vasttools/find_racs.py
@@ -281,6 +281,7 @@ else:
 if args.stokesv and not args.use_combined:
     print("Stokes V can only be used with combined mosaics at the moment.")
     print ("Run again with the option '--use-combined'.")
+    sys.exit()
 
 IMAGE_FOLDER = args.img_folder
 if not IMAGE_FOLDER:


### PR DESCRIPTION
Added the ability to use Stokes V instead of just I. Currently only works with combined images as we only have the catalogues for the field images in .xml and I couldn't be bothered to convert.

Positive and negative fluxes are recognised and are plotted with different colours in the png, annotation and region files. Negative source island names also begin with 'n'.

Also adds support for coordinates in degrees in the input.