### PR TITLE
Set astropy version to be < 4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ A space to share your hacky scripts that others may find useful.
 Currently these are scripts that can just be copied and run, not a module installation yet (soon).
 
 ## Requirements
-* Python 3
-* pandas
-* numpy
+* Python 3 (3.8.0)
+* pandas (0.25.3)
+* numpy (1.17.4)
 * astropy (<4.0)
-* matplotlib
-* scipy
-* dropbox
-* colorlog (optional)
+* matplotlib (3.1.2)
+* scipy (1.4.0)
+* dropbox (9.4.0)
+* colorlog (4.0.2 ;optional)
 
-Latest versions of above recommended unless stated.
+Recommended versions, which have been tested against, are stated in brackets.
 
 There is a requirements.txt included in the repository that you can use to install the dependancies using
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pandas>=0.25.2
-numpy>=1.16.4
-scipy>=1.3.1
+pandas<=0.25.3
+numpy<=1.17.4
+scipy<=1.4.0
 astropy<4.0
-matplotlib>=3.1.1
-colorlog>=4.0.2
-dropbox>=9.4.0
+matplotlib<=3.1.2
+colorlog<=4.0.2
+dropbox<=9.4.0


### PR DESCRIPTION
Astropy 4.0 has been released. Until version 4.0 has been fully tested the astropy version has been set to be < 4.0.

* Edited requirements.txt.
* Added < 4.0 in README.