### PR TITLE
Added crossmatch radius overlay

### DIFF
--- a/bin/find_sources.py
+++ b/bin/find_sources.py
@@ -565,10 +565,12 @@ for uf in uniq_fields:
             if source.selavy_fail is False:
                 source.filter_selavy_components(imsize)
                 if args.ann:
-                    source.write_ann(outfile,
+                    source.write_ann(
+                        outfile,
                         crossmatch_overlay=args.crossmatch_radius_overlay)
                 if args.reg:
-                    source.write_reg(outfile, 
+                    source.write_reg(
+                        outfile,
                         crossmatch_overlay=args.crossmatch_radius_overlay)
             else:
                 logger.error(

--- a/vasttools/source.py
+++ b/vasttools/source.py
@@ -43,11 +43,11 @@ class Source:
     :type SELAVY_FOLDER: str
     :param vast_pilot: Survey epoch (if applicable)
     :type vast_pilot: int or None
-    :param tiles: `True` if image tiles should be used, \
-    `False` for mosaiced images, defaults to `False`
+    :param tiles: `True` if image tiles should be used,
+        `False` for mosaiced images, defaults to `False`
     :type tiles: bool, optional
-    :param stokesv: `True` if Stokes V information is requested, \
-    `False` for Stokes I, defaults to `False`
+    :param stokesv: `True` if Stokes V information is requested,
+        `False` for Stokes I, defaults to `False`
     :type stokesv: bool, optional
     '''
 
@@ -96,8 +96,8 @@ class Source:
         :param wcs: World Coordinate System of the image
         :type wcs: `astropy.wcs.wcs.WCS`
         :param size: Size of the cutout array along each axis
-        :type size: `astropy.coordinates.angles.Angle` \
-        or tuple of two `Angle` objects
+        :type size: `astropy.coordinates.angles.Angle`
+            or tuple of two `Angle` objects
         :param outfile: Name of output FITS file
         :type outfile: str
         '''
@@ -177,8 +177,8 @@ class Source:
 
         :param crossmatch_radius: Crossmatch radius to use
         :type crossmatch_radius: `astropy.coordinates.angles.Angle`
-        :param stokesv: `True` to crossmatch with Stokes V image, \
-        `False` to match with Stokes I image, defaults to `False`
+        :param stokesv: `True` to crossmatch with Stokes V image,
+            `False` to match with Stokes I image, defaults to `False`
         :type stokesv: bool, optional
         '''
 
@@ -227,8 +227,8 @@ class Source:
             selavy_iflux = self.selavy_info['flux_int'].iloc[0]
             selavy_iflux_err = self.selavy_info['flux_int_err'].iloc[0]
             self.logger.info(
-                "Source in selavy catalogue {} {}, {:.3f}+/-{:.3f} mJy \
-                ({:.3f} arcsec offset)".format(
+                "Source in selavy catalogue {} {}, {:.3f}+/-{:.3f} mJy "
+                "({:.3f} arcsec offset)".format(
                     selavy_ra,
                     selavy_dec,
                     selavy_iflux,
@@ -251,8 +251,8 @@ class Source:
 
         :param outfile: Name of the file to write
         :type outfile: str
-        :param crossmatch_overlay: If True, a circle is added to the 
-            annotation file output denoting the crossmatch radius, 
+        :param crossmatch_overlay: If True, a circle is added to the
+            annotation file output denoting the crossmatch radius,
             defaults to False.
         :type crossmatch_overlay: bool, optional.
         '''
@@ -317,7 +317,7 @@ class Source:
 
         :param outfile: Name of the file to write
         :type outfile: str
-        :param crossmatch_overlay: If True, a circle is added to the region 
+        :param crossmatch_overlay: If True, a circle is added to the region
             file output denoting the crossmatch radius, defaults to False.
         :type crossmatch_overlay: bool, optional.
         '''
@@ -400,8 +400,8 @@ class Source:
         outside of the image
 
         :param imsize: Size of the image along each axis
-        :type imsize: `astropy.coordinates.angles.Angle` or tuple of two \
-        `Angle` objects
+        :type imsize: `astropy.coordinates.angles.Angle` or tuple of two
+            `Angle` objects
         '''
 
         seps = self.src_coord.separation(self.selavy_sc)
@@ -432,25 +432,25 @@ class Source:
         :type zscale: bool
         :param contrast: ZScale contrast to use
         :type contrast: float
-        :param outfile: Name of the file to write to, or the name of the FITS  
+        :param outfile: Name of the file to write to, or the name of the FITS
             file
         :type outfile: str
-        :param pa_corr: Correction to apply to ellipse position angle if 
+        :param pa_corr: Correction to apply to ellipse position angle if
             needed (in deg). Angle is from x-axis from left to right.
         :type pa_corr: float
-        :param no_islands: Disable island lables on the png, defaults to 
+        :param no_islands: Disable island lables on the png, defaults to
             `False`
         :type no_islands: bool, optional
-        :param label: Figure title (usually the name of the source of 
+        :param label: Figure title (usually the name of the source of
             interest), defaults to "Source"
         :type label: str, optional
-        :param no_colorbar: If `True`, do not show the colorbar on the png, 
+        :param no_colorbar: If `True`, do not show the colorbar on the png,
             defaults to `False`
         :type no_colorbar: bool, optional
-        :param title: String to set as title, 
+        :param title: String to set as title,
             defaults to `` where no title will be used.
         :type title: str, optional
-        :param crossmatch_overlay: If 'True' then a circle is added to the png 
+        :param crossmatch_overlay: If 'True' then a circle is added to the png
             plot representing the crossmatch radius, defaults to `False`.
         :type crossmatch_overlay: bool, optional
         '''
@@ -479,7 +479,7 @@ class Source:
         if crossmatch_overlay:
             try:
                 crossmatch_patch = SphericalCircle(
-                    (self.src_coord.ra,self.src_coord.dec),
+                    (self.src_coord.ra, self.src_coord.dec),
                     self.crossmatch_radius,
                     transform=ax.get_transform('world'),
                     label="Crossmatch radius ({:.1f} arcsec)".format(
@@ -535,13 +535,16 @@ class Source:
             self.logger.warning(
                 "PNG: No selavy selected or selavy catalogue failed.")
         legend_elements = [
-            Line2D([0], [0], marker='x', color='C3',label=label,
+            Line2D(
+                [0], [0], marker='x', color='C3', label=label,
                 markerfacecolor='g', ls="none", markersize=8),
-            Line2D([0], [0], marker='o', color='C1',label="Selavy Sources",
+            Line2D(
+                [0], [0], marker='o', color='C1', label="Selavy Sources",
                 markerfacecolor='none', ls="none", markersize=10)]
         if crossmatch_overlay:
             legend_elements.append(
-                Line2D([0], [0], marker='o', color='C4',
+                Line2D(
+                    [0], [0], marker='o', color='C4',
                     label="Crossmatch radius ({:.1f} arcsec)".format(
                         self.crossmatch_radius.arcsec),
                     markerfacecolor='none', ls="none",


### PR DESCRIPTION
* Added an option to overlay the crossmatch radius on the annotation, region and png file outputs.
* Once crossmatch has been done the source object saves the crossmatch_radius to the instance.
* Also updated selavy png overlay style.
* Will addresses #74.

Waiting on confirmation from Jess.