### PR TITLE
Issue 219 fix source names

### DIFF
--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -225,7 +225,7 @@ class Query:
 
         if self.coords is not None and len(self.source_names) == 0:
             self.source_names = [
-                i.to_string(
+                'source_' + i.to_string(
                     'hmsdms', sep="", precision=1
                 ).replace(" ", "") for i in self.coords
             ]


### PR DESCRIPTION
If coords are given and no names are given then names are automatically generated.

If coords and names are given but are different lengths then an exception occurs.

Fixes #219.