### PR TITLE
Fix lightcurve axist limits for forced fits

### DIFF
--- a/vasttools/source.py
+++ b/vasttools/source.py
@@ -620,16 +620,13 @@ class Source:
                 label=label)
 
         if yaxis_start == "0":
-            if use_forced_for_limits:
+            if use_forced_for_limits or self.pipeline:
                 max_y = np.nanmax(
                     detections[flux_col].tolist() +
                     upper_lims[value_col].tolist()
                 )
-            elif self.pipeline:
-                max_y = np.nanmax(
-                    detections[flux_col].tolist() +
-                    upper_lims[value_col].tolist()
-                )
+            elif use_forced_for_all:
+                max_y = np.nanmax(detections[flux_col].tolist())
             else:
                 max_y = np.nanmax(
                     detections[flux_col].tolist() +


### PR DESCRIPTION
I think this _should_ fix the issue, but I haven't got my own version of vast-tools set up on jupyterhub so I can't actually check...

I should probably get around to that.

Fix #256 