### PR TITLE
fixing typo in exception

### DIFF
--- a/vasttools/moc.py
+++ b/vasttools/moc.py
@@ -143,7 +143,7 @@ class VASTMOCS(object):
         if itype not in types:
             raise Exception(
                 "Image type not recognised. Valid entries are"
-                " 'COMBINED' or 'TILE'."
+                " 'COMBINED' or 'TILES'."
             )
 
         if field not in FIELD_CENTRES.field.values:


### PR DESCRIPTION
Fixes a typo in an exception:

```python
        if itype not in types:
            raise Exception(
                "Image type not recognised. Valid entries are"
                " 'COMBINED' or 'TILE'."
            )
```
to
```python
        if itype not in types:
            raise Exception(
                "Image type not recognised. Valid entries are"
                " 'COMBINED' or 'TILES'."
            )
```
since the first exception was incompatible with the actual value check.