### PR TITLE
Fixes TestQuery::test_init_failure_base_folder test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed test_query.py::TestQuery::test_init_failure_base_folder test [#291](https://github.com/askap-vast/vast-tools/pull/291).
 - Fixed jsmin dependancy install (2.2.2 -> 3.0.0) [#285](https://github.com/askap-vast/vast-tools/pull/285).
 - Remerged docs branch [#287](https://github.com/askap-vast/vast-tools/pull/287).
 - Docs branch reverted to avoid squashing to make merge of tests straightforward [#286](https://github.com/askap-vast/vast-tools/pull/286).
@@ -36,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#291](https://github.com/askap-vast/vast-tools/pull/291): tests: Fixed TestQuery::test_init_failure_base_folder test.
 - [#288](https://github.com/askap-vast/vast-tools/pull/288): docs, dep: Updated docs dependencies.
 - [#285](https://github.com/askap-vast/vast-tools/pull/285): test, feat, dep: Added codebase unit testing.
 - [#287](https://github.com/askap-vast/vast-tools/pull/287): docs, dep: Documentation using mkdocs

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -514,16 +514,23 @@ class TestQuery:
 
         assert str(excinfo.value) == "Invalid planet object provided!"
 
-    def test_init_failure_base_folder(self) -> None:
+    def test_init_failure_base_folder(self, mocker) -> None:
         """
         Tests the initialisation failure of a Query object.
 
         Specifically when the base folder directory has not been specified, or
         set in the environment.
 
+        Args:
+            mocker: The pytest-mock mocker object.
+
         Returns:
             None
         """
+        mocker_getenv = mocker.patch(
+            'os.getenv', return_value=None
+        )
+
         with pytest.raises(vtq.QueryInitError) as excinfo:
             query = vtq.Query(
                 planets=['Mars']


### PR DESCRIPTION
- Makes sure the os.getenv call returns `None`.
- Fixes problem reported in #277 when the `VAST_DATA_DIR` environment variable is set.