### PR TITLE
Add check for existence of requested data to Query init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added check for existence of requested data in `Query` init [#346](https://github.com/askap-vast/vast-tools/pull/346/)
 - Added pylint github action for pull requests and flake8 dev dependency [#338](https://github.com/askap-vast/vast-tools/pull/338).
 - Added observing frequency to all fields csv files [#311](https://github.com/askap-vast/vast-tools/pull/311)
 - Added OBSERVED_EPOCHS variable for epochs that have been observed but not yet released [#311](https://github.com/askap-vast/vast-tools/pull/311)
@@ -43,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#346](https://github.com/askap-vast/vast-tools/pull/346/): feat, fix, tests: Check if requested data exists in Query init
 - [#345](https://github.com/askap-vast/vast-tools/pull/345): fix: Fixed plot_lightcurve
 - [#338](https://github.com/askap-vast/vast-tools/pull/338): feat, dep: Added pylint workflow for pull requests.
 - [#340](https://github.com/askap-vast/vast-tools/pull/340): fix: Fixed eta-v plot

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -726,14 +726,14 @@ class TestQuery:
         "epoch_exists,data_dir_exists,images_exist,"
         "cats_exist,rmsmaps_exist,no_rms,all_available",
         [
-            (True,True,True,True,True,False,True),
-            (True,True,True,True,True,True,True),
-            (False,True,True,True,True,False,False),
-            (True,False,True,True,True,False,False),
-            (True,True,False,True,True,False,False),
-            (True,True,True,False,True,False,False),
-            (True,True,True,True,False,False,False),
-            (True,True,True,True,False,True,True),
+            (True, True, True, True, True, False, True),
+            (True, True, True, True, True, True, True),
+            (False, True, True, True, True, False, False),
+            (True, False, True, True, True, False, False),
+            (True, True, False, True, True, False, False),
+            (True, True, True, False, True, False, False),
+            (True, True, True, True, False, False, False),
+            (True, True, True, True, False, True, True),
         ],
         ids=('all-available',
              'all-available-no-rms',
@@ -743,7 +743,7 @@ class TestQuery:
              'no-selavy-dir',
              'no-rms-dir-rms',
              'no-rms-dir-no-rms'
-            )
+             )
     )
     def test__check_data_availability(self,
                                       epoch_exists: bool,
@@ -754,10 +754,10 @@ class TestQuery:
                                       no_rms: bool,
                                       all_available: bool,
                                       tmp_path
-    ) -> None:
+                                      ) -> None:
         """
         Test the data availability check
-        
+
         Args:
             epoch_exists: The epoch directory exists.
             data_dir_exists: The data directory (i.e. COMBINED/TILES) exists.
@@ -767,21 +767,21 @@ class TestQuery:
             no_rms: The `no_rms` Query option has been selected.
             all_available: The expected result from _check_data_availability().
             tmp_path: Pathlib temporary directory path.
-        
+
         Returns:
             None.
         """
         stokes = "I"
         epoch = "10x"
         data_type = "COMBINED"
-        
+
         base_dir = tmp_path
         epoch_dir = base_dir / f"EPOCH{epoch}"
         data_dir = epoch_dir / data_type
         image_dir = data_dir / f"STOKES{stokes}_IMAGES"
         selavy_dir = data_dir / f"STOKES{stokes}_SELAVY"
         rms_dir = data_dir / f"STOKES{stokes}_RMSMAPS"
-        
+
         if epoch_exists:
             epoch_dir.mkdir()
             if data_dir_exists:
@@ -792,7 +792,6 @@ class TestQuery:
                     selavy_dir.mkdir()
                 if rmsmaps_exist:
                     rms_dir.mkdir()
-            
 
         if all_available:
             expectation = does_not_raise()
@@ -800,8 +799,8 @@ class TestQuery:
         else:
             expectation = pytest.raises(vtq.QueryInitError)
             message = ("Not all requested data is available!"
-                "Please address and try again.")
-            
+                       "Please address and try again.")
+
         with expectation as e:
             query = vtq.Query(
                 epochs=epoch,
@@ -811,7 +810,7 @@ class TestQuery:
                 no_rms=no_rms
             )
             assert str(e) == message
-        
+
     def test__field_matching(
         self,
         vast_query_psrj2129: vtq.Query,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -8,6 +8,7 @@ import pytest
 from astropy.coordinates import SkyCoord, Angle
 from mocpy import MOC
 from pytest_mock import mocker  # noqa: F401
+from contextlib import nullcontext as does_not_raise
 
 import vasttools.query as vtq
 
@@ -57,6 +58,11 @@ def vast_query_psrj2129(pilot_moc_mocker: MOC, mocker) -> vtq.Query:
         'mocpy.MOC.from_fits',
         return_value=pilot_moc_mocker
     )
+    mocker_data_available = mocker.patch(
+        'vasttools.query.Query._check_data_availability',
+        return_value=True
+    )
+
     psr_coordinate = SkyCoord(322.4387083, -4.4866389, unit=(u.deg, u.deg))
 
     psr_query = vtq.Query(
@@ -613,6 +619,10 @@ class TestQuery:
                 'vasttools.query.os.path.isdir',
                 return_value=True
             )
+            mocker_data_available = mocker.patch(
+                'vasttools.query.Query._check_data_availability',
+                return_value=True
+            )
 
             mocker_moc_open = mocker.patch(
                 'mocpy.MOC.from_fits',
@@ -652,6 +662,11 @@ class TestQuery:
             'vasttools.query.os.path.isdir',
             return_value=True
         )
+        mocker_data_available = mocker.patch(
+            'vasttools.query.Query._check_data_availability',
+            return_value=True
+        )
+
         test_dir = '/testing/folder'
         epochs = '1,2,3x'
         stokes = 'I'
@@ -707,6 +722,96 @@ class TestQuery:
 
         assert query.settings == expected_settings
 
+    @pytest.mark.parametrize(
+        "epoch_exists,data_dir_exists,images_exist,"
+        "cats_exist,rmsmaps_exist,no_rms,all_available",
+        [
+            (True,True,True,True,True,False,True),
+            (True,True,True,True,True,True,True),
+            (False,True,True,True,True,False,False),
+            (True,False,True,True,True,False,False),
+            (True,True,False,True,True,False,False),
+            (True,True,True,False,True,False,False),
+            (True,True,True,True,False,False,False),
+            (True,True,True,True,False,True,True),
+        ],
+        ids=('all-available',
+             'all-available-no-rms',
+             'no-epoch',
+             'no-data-dir',
+             'no-image-dir',
+             'no-selavy-dir',
+             'no-rms-dir-rms',
+             'no-rms-dir-no-rms'
+            )
+    )
+    def test__check_data_availability(self,
+                                      epoch_exists: bool,
+                                      data_dir_exists: bool,
+                                      images_exist: bool,
+                                      cats_exist: bool,
+                                      rmsmaps_exist: bool,
+                                      no_rms: bool,
+                                      all_available: bool,
+                                      tmp_path
+    ) -> None:
+        """
+        Test the data availability check
+        
+        Args:
+            epoch_exists: The epoch directory exists.
+            data_dir_exists: The data directory (i.e. COMBINED/TILES) exists.
+            images_exist: The image directory (e.g. STOKESI_IMAGES) exists.
+            cats_exist: The selavy directory (e.g. STOKESI_SELAVY) exists.
+            rmsmaps_exist: The RMS map directory (e.g. STOKESI_RMSMAPS) exists.
+            no_rms: The `no_rms` Query option has been selected.
+            all_available: The expected result from _check_data_availability().
+            tmp_path: Pathlib temporary directory path.
+        
+        Returns:
+            None.
+        """
+        stokes = "I"
+        epoch = "10x"
+        data_type = "COMBINED"
+        
+        base_dir = tmp_path
+        epoch_dir = base_dir / f"EPOCH{epoch}"
+        data_dir = epoch_dir / data_type
+        image_dir = data_dir / f"STOKES{stokes}_IMAGES"
+        selavy_dir = data_dir / f"STOKES{stokes}_SELAVY"
+        rms_dir = data_dir / f"STOKES{stokes}_RMSMAPS"
+        
+        if epoch_exists:
+            epoch_dir.mkdir()
+            if data_dir_exists:
+                data_dir.mkdir()
+                if images_exist:
+                    image_dir.mkdir()
+                if cats_exist:
+                    selavy_dir.mkdir()
+                if rmsmaps_exist:
+                    rms_dir.mkdir()
+            
+
+        if all_available:
+            expectation = does_not_raise()
+            message = 'None'
+        else:
+            expectation = pytest.raises(vtq.QueryInitError)
+            message = ("Not all requested data is available!"
+                "Please address and try again.")
+            
+        with expectation as e:
+            query = vtq.Query(
+                epochs=epoch,
+                planets=['Mars'],
+                base_folder=base_dir,
+                stokes=stokes,
+                no_rms=no_rms
+            )
+            assert str(e) == message
+        
     def test__field_matching(
         self,
         vast_query_psrj2129: vtq.Query,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -798,7 +798,7 @@ class TestQuery:
             message = 'None'
         else:
             expectation = pytest.raises(vtq.QueryInitError)
-            message = ("Not all requested data is available!"
+            message = ("Not all requested data is available! "
                        "Please address and try again.")
 
         with expectation as e:

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -457,6 +457,7 @@ class Query:
             if not epoch_dir.is_dir():
                 self.logger.critical(f"Epoch {epoch} does not exist.")
                 all_available = False
+                continue
 
             data_dir = epoch_dir / data_type
             if not data_dir.is_dir():
@@ -464,6 +465,7 @@ class Query:
                     f"{data_type} unavailable for epoch {epoch}"
                 )
                 all_available = False
+                continue
 
             image_dir = data_dir / f"STOKES{stokes}_IMAGES{corrected_str}"
             if not image_dir.is_dir():

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -380,6 +380,13 @@ class Query:
                 "\nPlease address and try again."
             ))
 
+        data_available = self._check_data_availability()
+        if not data_available:
+            raise QueryInitError((
+                "Not all requested data is available!"
+                "Please address and try again."
+            ))
+
         if self.coords is not None:
             self.query_df = self._build_catalog()
             if self.query_df.empty:
@@ -418,9 +425,6 @@ class Query:
                 "Image RMS and peak flux error are not available with islands."
                 "Using background_noise as a placeholder for both."
             )
-        data_available = self._check_data_availability()
-        if not data_available:
-            return False
 
         return True
 
@@ -442,7 +446,7 @@ class Query:
         if self.settings['tiles']:
             data_type = "TILES"
             if self.corrected_data:
-                corrected = "_CORRECTED"
+                corrected_str = "_CORRECTED"
 
         stokes = self.settings['stokes']
 
@@ -451,7 +455,7 @@ class Query:
         for epoch in self.settings['epochs']:
             epoch_dir = base_dir / "EPOCH{}".format(RELEASED_EPOCHS[epoch])
             if not epoch_dir.is_dir():
-                self.logger.critical(f"Epoch {epoch} does not exist.}")
+                self.logger.critical(f"Epoch {epoch} does not exist.")
                 all_available = False
 
             data_dir = epoch_dir / data_type
@@ -461,21 +465,21 @@ class Query:
                 )
                 all_available = False
 
-            image_dir = data_dir / f"STOKES{stokes}_IMAGES{corrected}"
+            image_dir = data_dir / f"STOKES{stokes}_IMAGES{corrected_str}"
             if not image_dir.is_dir():
                 self.logger.critical(
                     f"Stokes {stokes} images unavailable for epoch {epoch}"
                 )
                 all_available = False
 
-            selavy_dir = data_dir / f"STOKES{stokes}_SELAVY{corrected}"
+            selavy_dir = data_dir / f"STOKES{stokes}_SELAVY{corrected_str}"
             if not selavy_dir.is_dir():
                 self.logger.critical(
                     f"Stokes {stokes} catalogues unavailable for epoch {epoch}"
                 )
                 all_available = False
 
-            rms_dir = data_dir / f"STOKES{stokes}_RMSMAPS{corrected}"
+            rms_dir = data_dir / f"STOKES{stokes}_RMSMAPS{corrected_str}"
             if not rms_dir.is_dir() and not self.settings["no_rms"]:
                 self.logger.critical(
                     f"Stokes {stokes} catalogues unavailable for epoch {epoch}"

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -383,7 +383,7 @@ class Query:
         data_available = self._check_data_availability()
         if not data_available:
             raise QueryInitError((
-                "Not all requested data is available!"
+                "Not all requested data is available! "
                 "Please address and try again."
             ))
 

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -455,15 +455,17 @@ class Query:
         for epoch in self.settings['epochs']:
             epoch_dir = base_dir / "EPOCH{}".format(RELEASED_EPOCHS[epoch])
             if not epoch_dir.is_dir():
-                self.logger.critical(f"Epoch {epoch} does not exist.")
+                self.logger.critical(f"Epoch {epoch} is unavailable.")
+                self.logger.debug(f"{epoch_dir} does not exist.")
                 all_available = False
                 continue
 
             data_dir = epoch_dir / data_type
             if not data_dir.is_dir():
                 self.logger.critical(
-                    f"{data_type} unavailable for epoch {epoch}"
+                    f"{data_type} data unavailable for epoch {epoch}"
                 )
+                self.logger.debug(f"{data_dir} does not exist.")
                 all_available = False
                 continue
 
@@ -472,6 +474,7 @@ class Query:
                 self.logger.critical(
                     f"Stokes {stokes} images unavailable for epoch {epoch}"
                 )
+                self.logger.debug(f"{image_dir} does not exist.")
                 all_available = False
 
             selavy_dir = data_dir / f"STOKES{stokes}_SELAVY{corrected_str}"
@@ -479,6 +482,7 @@ class Query:
                 self.logger.critical(
                     f"Stokes {stokes} catalogues unavailable for epoch {epoch}"
                 )
+                self.logger.debug(f"{selavy_dir} does not exist.")
                 all_available = False
 
             rms_dir = data_dir / f"STOKES{stokes}_RMSMAPS{corrected_str}"
@@ -486,6 +490,7 @@ class Query:
                 self.logger.critical(
                     f"Stokes {stokes} catalogues unavailable for epoch {epoch}"
                 )
+                self.logger.debug(f"{rms_dir} does not exist.")
                 all_available = False
 
         if all_available:

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -489,7 +489,7 @@ class Query:
                 all_available = False
 
         if all_available:
-            self.logger.info("All data is available!")
+            self.logger.info("All requested data is available!")
 
         return all_available
 


### PR DESCRIPTION
Fix #339.

This code will check that the requested data exists at the initialisation of a `Query` object. It checks that the relevant directories exist and assumes that if those directories exist then the catalogues/fits files it should contain also exist.

The goal is a quick first-pass check to see if the data is available (since, e.g., nimbus doesn't have any Stokes Q/U/V data) with a nice exit if it doesn't. Adding a check that all files exist is quite cumbersome and probably unnecessary, as the query will still fail somewhat nicely (i.e. it includes the filepath in the traceback) if they don't.

This solution doesn't directly fix #339, mostly because the jupyterhub instances don't have unique hostnames and therefore a simple hostname check is not feasible. Restricting access to Stokes Q/U/V data to ada is not ideal as some users may have downloaded full stokes data to their own machines.  However, this solution is more general and produces a similar outcome while also handling any other instances of missing data (e.g. there is currently no COMBINED data for some epochs on nimbus, there are a number of missing epochs on ada)