### PR TITLE
Set dask npartition to minimum of ncpu or number of unique sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed issue with ncpu exceeding number of unique sources in Query._init_sources [#363](https://github.com/askap-vast/vast-tools/pull/363)
 - Fixed plot_lightcurve legend creation [#345](https://github.com/askap-vast/vast-tools/pull/345)
 - Fixed pipeline eta-v matplotlib plot [#340](https://github.com/askap-vast/vast-tools/pull/340)
 - Fixed pandas dataframe and series append deprecation by using `pd.concat` [#337](https://github.com/askap-vast/vast-tools/pull/337).
@@ -46,8 +47,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#363](https://github.com/askap-vast/vast-tools/pull/363): fix: Update dask npartition specification in Query._init_sources call.
 - [#351](https://github.com/askap-vast/vast-tools/pull/351): fix, fear: Add epoch 21.
-- [#346](https://github.com/askap-vast/vast-tools/pull/346/): feat, fix, tests: Check if requested data exists in Query init
+- [#346](https://github.com/askap-vast/vast-tools/pull/346): feat, fix, tests: Check if requested data exists in Query init
 - [#345](https://github.com/askap-vast/vast-tools/pull/345): fix: Fixed plot_lightcurve
 - [#338](https://github.com/askap-vast/vast-tools/pull/338): feat, dep: Added pylint workflow for pull requests.
 - [#340](https://github.com/askap-vast/vast-tools/pull/340): fix: Fixed eta-v plot

--- a/vasttools/query.py
+++ b/vasttools/query.py
@@ -1228,13 +1228,14 @@ class Query:
                 columns={'#': 'distance'}
             )
         else:
+            npart = min(self.ncpu, self.crossmatch_results.name.nunique())
             self.results = (
-                dd.from_pandas(self.crossmatch_results, self.ncpu)
+                dd.from_pandas(self.crossmatch_results, npart)
                 .groupby('name')
                 .apply(
                     self._init_sources,
                     meta=meta,
-                ).compute(num_workers=self.ncpu, scheduler='processes')
+                ).compute(num_workers=npart, scheduler='processes')
             )
             self.results = self.results.dropna()
 


### PR DESCRIPTION
Fix #362.

If the number of partitions (previously specified with `self.ncpu`) exceeds the number of unique sources here

https://github.com/askap-vast/vast-tools/blob/0957f52f4f4d1f496bd6fac4c20e3e93034e75de/vasttools/query.py#L1231-L1238

then the grouping produces empty dataframes, which breaks the call to `self._init_sources`. This fix changes the number of partitions to be the minimum of the number of unique sources and cpus.