### PR TITLE
Account for pipeline runs with no measurement pairs file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Exit nicely when users try to use measurement pairs but they do not exist [#478](https://github.com/askap-vast/vast-tools/pull/478)
 - Fixed missing RMS measurements for non-detections [#476](https://github.com/askap-vast/vast-tools/pull/476)
 - Removed duplicates in field matching [#472](https://github.com/askap-vast/vast-tools/pull/472)
 - Fix read_selavy to force all flux & flux_err values to be positive [#463](https://github.com/askap-vast/vast-tools/pull/463)
@@ -105,6 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#478](https://github.com/askap-vast/vast-tools/pull/478): fix: Account for pipeline runs with no measurement pairs file 
 - [#480](https://github.com/askap-vast/vast-tools/pull/480): feat: Added open_fits function to handle compressed image HDUs
 - [#476](https://github.com/askap-vast/vast-tools/pull/476): fix: Fixed missing RMS measurements for non-detections 
 - [#472](https://github.com/askap-vast/vast-tools/pull/472): fix: Remove duplicates in field matching

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -990,7 +990,7 @@ class TestPipeAnalysis:
         
         Args:
             pairs_existence: A list of booleans corresponding to whether a
-                pairs file exists. 
+                pairs file exists.
             dummy_PipeAnalysis_base: The base dummy PipeAnalysis object.
             mocker: The pytest-mock mocker object.
         

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -350,12 +350,12 @@ def load_parquet_side_effect(
 
 
 @pytest.fixture
-def dummy_PipeAnalysis(
+def dummy_PipeAnalysis_base(
     dummy_pipeline_object: vtp.Pipeline,
     mocker: MockerFixture
 ) -> vtp.PipeAnalysis:
     """
-    A dummy PipeAnalysis object used in testing.
+    The base dummy PipeAnalysis object used in testing.
 
     Because the raw pipeline outputs are processed in the load run function
     it is easier to test while creating the object each time. It is a little
@@ -382,16 +382,43 @@ def dummy_PipeAnalysis(
     dask_read_parquet_mocker.return_value.compute.return_value = (
         dummy_pipeline_measurements()
     )
-    measurement_pairs_existence_mocker = mocker.patch(
-        'vasttools.pipeline.PipeRun._check_measurement_pairs_file',
-        return_value=True
-    )
 
     pipe = dummy_pipeline_object
     run_name = 'test_run'
     run = pipe.load_run(run_name)
 
     return run
+
+
+@pytest.fixture
+def dummy_PipeAnalysis(
+    dummy_PipeAnalysis_base: vtp.PipeAnalysis,
+    mocker: MockerFixture
+) -> vtp.PipeAnalysis:
+    """
+    The dummy PipeAnalysis object used for most testing.
+
+    Because the raw pipeline outputs are processed in the load run function
+    it is easier to test while creating the object each time. It is a little
+    inefficient and really the pipeline process should be refactored slightly
+    to support better testing.
+
+    Args:
+        dummy_PipeAnalysis_base: The base vtp.PipeAnalysis fixture
+        mocker: The pytest mock mocker object.
+
+    Returns:
+        The vtp.PipeAnalysis instance.
+    """
+
+    measurement_pairs_existence_mocker = mocker.patch(
+        'vasttools.pipeline.PipeRun._check_measurement_pairs_file',
+        return_value=True
+    )
+
+    dummy_PipeAnalysis_base._measurement_pairs_exists = True
+
+    return dummy_PipeAnalysis_base
 
 
 @pytest.fixture
@@ -937,6 +964,55 @@ class TestPipeAnalysis:
     the pipeline component.
     """
 
+    @pytest.mark.parametrize(
+        "pairs_existence",
+        [
+            [True],
+            [False],
+            [True,True],
+            [False,False],
+            [True,False],
+        ],
+        ids=("single-exists",
+             "single-no-exists",
+             "multiple-all-exists",
+             "multiple-no-exists",
+             "multiple-some-exists",
+             )
+     )
+    def test__check_measurement_pairs_file(self,
+        pairs_existence: List[bool],
+        dummy_PipeAnalysis_base: vtp.PipeAnalysis,
+        mocker: MockerFixture
+        ) -> None:
+        """
+        Tests the _check_measurement_pairs_file method.
+        
+        Args:
+            pairs_existence: A list of booleans corresponding to whether a
+                pairs file exists. 
+            dummy_PipeAnalysis_base: The base dummy PipeAnalysis object.
+            mocker: The pytest-mock mocker object.
+        
+        Returns:
+            None
+        """
+        mocker_isfile = mocker.patch(
+            "os.path.isfile",
+            side_effect=pairs_existence
+        )
+        
+        fake_pairs_file = [""]*len(pairs_existence)
+        
+        dummy_PipeAnalysis_base.measurement_pairs_file = fake_pairs_file
+        
+        returned_val = dummy_PipeAnalysis_base._check_measurement_pairs_file()
+        
+        all_exist = sum(pairs_existence) == len(pairs_existence)
+        
+        assert returned_val == all_exist
+        
+    
     def test_combine_with_run(
         self,
         dummy_PipeAnalysis: vtp.PipeAnalysis

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -382,6 +382,10 @@ def dummy_PipeAnalysis(
     dask_read_parquet_mocker.return_value.compute.return_value = (
         dummy_pipeline_measurements()
     )
+    measurement_pairs_existence_mocker = mocker.patch(
+        'vasttools.pipeline.PipeRun._check_measurement_pairs_file',
+        return_value=True
+    )
 
     pipe = dummy_pipeline_object
     run_name = 'test_run'

--- a/vasttools/pipeline.py
+++ b/vasttools/pipeline.py
@@ -161,9 +161,11 @@ class PipeRun(object):
 
         self.logger = logging.getLogger('vasttools.pipeline.PipeRun')
         self.logger.debug('Created PipeRun instance')
+        
+        self.measurement_pairs_exists = self._check_measurement_pairs_file()
 
-    def _check_measuremnt_pairs_file(self):
-        self.measurement_pairs_exists = True
+    def _check_measurement_pairs_file(self):
+        measurement_pairs_exists = True
         
         for filepath in self.measurement_pairs_file:
             if not os.path.isfile(filepath):
@@ -171,7 +173,9 @@ class PipeRun(object):
                                     " not exist. You will be unable to access"
                                     " measurement pairs or two-epoch metrics."
                                     )
-                self.measurement_pairs_exists = False
+                measurement_pairs_exists = False
+
+        return measurement_pairs_exists
             
     def combine_with_run(
         self, other_PipeRun, new_name: Optional[str] = None
@@ -238,7 +242,8 @@ class PipeRun(object):
         if self.measurement_pairs_exists:
             for i in other_PipeRun.measurement_pairs_file:
                 self.measurement_pairs_file.append(i)
-            self._check_measurement_pairs_file()
+            measurement_pairs_exists = self._check_measurement_pairs_file()
+            self.measurement_pairs_exists = measurement_pairs_exists
         else:
             self.logger.warning("Not combining measurement pairs because they "
                                 " do not exist for the original run."

--- a/vasttools/pipeline.py
+++ b/vasttools/pipeline.py
@@ -240,7 +240,7 @@ class PipeRun(object):
         # need to keep access to all the different pairs files
         # for two epoch metrics.
         orig_run_pairs_exist = self._measurement_pairs_exists
-        other_run_pairs_exist = other_PipeRun.measurement_pairs_exists
+        other_run_pairs_exist = other_PipeRun._measurement_pairs_exists
 
         if orig_run_pairs_exist and other_run_pairs_exist:
             for i in other_PipeRun.measurement_pairs_file:

--- a/vasttools/pipeline.py
+++ b/vasttools/pipeline.py
@@ -1098,7 +1098,7 @@ class PipeAnalysis(PipeRun):
                 exist for this run
         """
         
-        self.raise_if_no_pairs()
+        self._raise_if_no_pairs()
 
         # Two epoch metrics
         if not self._loaded_two_epoch_metrics:
@@ -1708,7 +1708,7 @@ class PipeAnalysis(PipeRun):
                 exist for this run
         """
 
-        self.raise_if_no_pairs()
+        self._raise_if_no_pairs()
 
         if not self._loaded_two_epoch_metrics:
             raise Exception(
@@ -1804,7 +1804,7 @@ class PipeAnalysis(PipeRun):
                 exist for this run
         """
         
-        self.raise_if_no_pairs()
+        self._raise_if_no_pairs()
 
         if not self._loaded_two_epoch_metrics:
             raise Exception(

--- a/vasttools/pipeline.py
+++ b/vasttools/pipeline.py
@@ -162,7 +162,7 @@ class PipeRun(object):
         self.logger = logging.getLogger('vasttools.pipeline.PipeRun')
         self.logger.debug('Created PipeRun instance')
         
-        self.measurement_pairs_exists = self._check_measurement_pairs_file()
+        self._measurement_pairs_exists = self._check_measurement_pairs_file()
 
     def _check_measurement_pairs_file(self):
         measurement_pairs_exists = True
@@ -239,12 +239,20 @@ class PipeRun(object):
 
         # need to keep access to all the different pairs files
         # for two epoch metrics.
-        if self.measurement_pairs_exists:
+        orig_run_pairs_exist = self._measurement_pairs_exists
+        other_run_pairs_exist = other_PipeRun.measurement_pairs_exists
+
+        if orig_run_pairs_exist and other_run_pairs_exist:
             for i in other_PipeRun.measurement_pairs_file:
                 self.measurement_pairs_file.append(i)
-            measurement_pairs_exists = self._check_measurement_pairs_file()
-            self.measurement_pairs_exists = measurement_pairs_exists
-        else:
+        
+        elif orig_run_pairs_exist:
+            self.logger.warning("Not combining measurement pairs because they "
+                                " do not exist for the new run."
+                                )
+            self._measurement_pairs_exists = False
+
+        elif other_run_pairs_exist:
             self.logger.warning("Not combining measurement pairs because they "
                                 " do not exist for the original run."
                                 )
@@ -448,7 +456,7 @@ class PipeRun(object):
             AttributeError: Measurement pairs do not exist for this run.
         """
         
-        if not self.measurement_pairs_exists:
+        if not self._measurement_pairs_exists:
             raise AttributeError("Unable to load two epoch metrics because "
                                  "measurement pairs do not exist for this run."
                                  )
@@ -1682,7 +1690,7 @@ class PipeAnalysis(PipeRun):
             AttributeError: Measurement pairs do not exist for this run.
         """
 
-        if not self.measurement_pairs_exists:
+        if not self._measurement_pairs_exists:
             raise AttributeError("Cannot plot two epoch metrics because "
                                  "measurement pairs do not exist for this run."
                                  )
@@ -1779,7 +1787,7 @@ class PipeAnalysis(PipeRun):
                 function.
             AttributeError: Measurement pairs do not exist for this run.
         """
-        if not self.measurement_pairs_exists:
+        if not self._measurement_pairs_exists:
             raise AttributeError("Unable to run two epoch analysis because "
                                  "measurement pairs do not exist for this run."
                                  )

--- a/vasttools/pipeline.py
+++ b/vasttools/pipeline.py
@@ -169,9 +169,9 @@ class PipeRun(object):
         
         for filepath in self.measurement_pairs_file:
             if not os.path.isfile(filepath):
-                self.logger.warning("Measurement pairs file ({filepath}) does"
-                                    " not exist. You will be unable to access"
-                                    " measurement pairs or two-epoch metrics."
+                self.logger.warning(f"Measurement pairs file ({filepath}) does"
+                                    f" not exist. You will be unable to access"
+                                    f" measurement pairs or two-epoch metrics."
                                     )
                 measurement_pairs_exists = False
 


### PR DESCRIPTION
This PR adds a check for the measurement_pairs files existence and if they do not exist, disables the relevant functionality.

The testing is also updated appropriately.